### PR TITLE
Successories

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,10 +6,11 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/core.async "0.4.474"]
                  [camel-snake-kebab "0.4.0"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 [com.taoensso/timbre "4.10.0"]]
   :deploy-repositories [["clojars-https" {:url "https://clojars.org/repo"
                                           :username :env/clojars_user
                                           :password :env/clojars_password}]]
   :profiles {:uberjar {:aot :all}
-             :dev {:dependencies [[midje "1.9.0"]]
+             :dev {:dependencies [[midje "1.9.1"]]
                    :plugins [[lein-midje "3.2.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject waffletower/serum "0.3.0"
+(defproject waffletower/serum "0.4.0"
   :description "Clojure library of utility functions and macros"
   :url "https://github.com/waffletower/serum"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]
                  [camel-snake-kebab "0.4.0"]
                  [slingshot "0.12.2"]]
   :deploy-repositories [["clojars-https" {:url "https://clojars.org/repo"

--- a/src/serum/async.clj
+++ b/src/serum/async.clj
@@ -1,0 +1,55 @@
+(ns serum.async
+  (:require [clojure.core.async :as a]
+            [taoensso.timbre :as log]))
+
+(defmacro fire!
+  "execute 'body' on an asynchronous worker thread via a core.async channel.
+  (fire! and forget)"
+  [body]
+  `(a/go
+     (let [channel# (a/chan)]
+       (a/>!
+        channel#
+        (do
+          (try
+            (~@body)
+            (catch
+                Throwable
+                exception#
+              (do
+                (log/error "fire! caught exception on worker thread:")
+                (log/error exception#))))
+          (a/close! channel#)
+          true)))))
+
+(defn chan->seq
+  "recursive function which derives a lazy sequence from a core.async channel, 'channel'"
+  [channel]
+  (lazy-seq
+   (when-let [took (a/<!! channel)]
+     (cons took (chan->seq channel)))))
+
+(defn map-async
+  "an asynchronous implementation of 'map'
+  returns a lazy sequence of the asynchronous evaluation of 'f' applied to members of the collection 'coll'
+  will block until all asynchronous evaluation completes
+  'f' single-argument function
+  'n' parallelization parameter
+  'coll' collection applied to the function 'f'"
+  ([f coll]
+   (map-async
+    f
+    (.. Runtime getRuntime availableProcessors)
+    coll))
+  ([f n coll]
+   (let [input-channel (a/chan n)
+         output-channel (a/chan n)]
+     (a/onto-chan input-channel coll)
+     (a/pipeline-async
+      n
+      output-channel
+      (fn [x c]
+        (a/>!! c (f x))
+        (a/close! c))
+      input-channel)
+     (chan->seq output-channel))))

--- a/src/serum/core.clj
+++ b/src/serum/core.clj
@@ -87,3 +87,17 @@
   `(try
      ~expr
      (catch Exception e# (~f e#))))
+
+(defmacro success->
+  [x & forms]
+  (if forms
+    (let [form (first forms)
+          cur (if (seq? form)
+                `(~(first form) ~x ~@(next form))
+                (list form x))
+          nxt (next forms)]
+      `(success-let
+        [y# ~cur]
+        (success-> y# ~@nxt)
+        y#))
+    x))

--- a/src/serum/core.clj
+++ b/src/serum/core.clj
@@ -100,3 +100,11 @@
         (success-> y# ~@(next forms))
         y#))
     x))
+
+(defmacro divert
+  "derived from (with-out-str).  Evaluates body, captures any output destined to *out*, and returns result
+  of body and text output as a vector tuple, [~@body captured-output-string]"
+  [& body]
+  `(let [s# (new java.io.StringWriter)]
+     (binding [*out* s#]
+       [~@body (str s#)])))

--- a/src/serum/core.clj
+++ b/src/serum/core.clj
@@ -94,10 +94,9 @@
     (let [form (first forms)
           cur (if (seq? form)
                 `(~(first form) ~x ~@(next form))
-                (list form x))
-          nxt (next forms)]
+                (list form x))]
       `(success-let
         [y# ~cur]
-        (success-> y# ~@nxt)
+        (success-> y# ~@(next forms))
         y#))
     x))

--- a/test/serum/t_async.clj
+++ b/test/serum/t_async.clj
@@ -1,0 +1,29 @@
+(ns serum.t-async
+  (:require [clojure.string :refer [lower-case]]
+            [clojure.core.async :as a]
+            [serum.async :refer :all]
+            [midje.sweet :refer :all]))
+
+(let [side-effect (atom false)]
+  (fire! (do
+           (Thread/sleep 40)
+           (reset! side-effect true)))
+  (Thread/sleep 100)
+  (fact "fire!"
+    @side-effect => truthy)
+  (reset! side-effect false)
+  (fire! (do
+           (Thread/sleep 100)
+           (reset! side-effect true)))
+  (fact "fire!"
+    @side-effect => falsey))
+
+(let [channel (a/chan)]
+  (a/onto-chan
+   channel
+   ["progress" "ridge" "ottoman"])
+  (fact "chan->seq"
+    (doall (chan->seq channel)) => ["progress" "ridge" "ottoman"]))
+
+(fact "map-async"
+  (doall (map-async lower-case ["Cubby" "Slime" "Cache"])) => ["cubby" "slime" "cache"])

--- a/test/serum/t_core.clj
+++ b/test/serum/t_core.clj
@@ -164,7 +164,7 @@
                      (-> m
                          (assoc :success false)))]
 
-  (future-fact "success-> all succeeding list-free"
+  (fact "success-> all succeeding list-free"
                (success-> {}
                           colorizer
                           weaponizer
@@ -173,7 +173,7 @@
                                         :weapon "doughnut"
                                         :outfit "beanie"})
 
-  (future-fact "success-> all succeeding list-full"
+  (fact "success-> all succeeding list-full"
                (success-> {}
                           (colorizer)
                           (weaponizer)
@@ -182,7 +182,7 @@
                                           :weapon "doughnut"
                                           :outfit "beanie"})
 
-  (future-fact "success-> all succeeding list-full redux"
+  (fact "success-> all succeeding list-full redux"
                (success-> (colorizer {})
                           (weaponizer)
                           (hipifier)) => {:success true
@@ -190,21 +190,21 @@
                                           :weapon "doughnut"
                                           :outfit "beanie"})
 
-  (future-fact "success-> first failure list-free"
+  (fact "success-> first failure list-free"
                (success-> {}
                           love-infuser
                           colorizer
                           weaponizer
                           hipifier) => {:success false})
 
-  (future-fact "success-> first failure list-full"
+  (fact "success-> first failure list-full"
                (success-> {}
                           (love-infuser)
                           (colorizer)
                           (weaponizer)
                           (hipifier)) => {:success false})
 
-  (future-fact "success-> final failure mixed listness"
+  (fact "success-> final failure mixed listness"
                (success-> (colorizer {})
                           weaponizer
                           hipifier
@@ -213,7 +213,7 @@
                                             :weapon "doughnut"
                                             :outfit "beanie"})
 
-  (future-fact "success-> final failure list-full"
+  (fact "success-> final failure list-full"
                (success-> {}
                           (colorizer)
                           (weaponizer)
@@ -223,7 +223,7 @@
                                               :weapon "doughnut"
                                               :outfit "beanie"})
 
-  (future-fact "success-> another failure possibility"
+  (fact "success-> another failure possibility"
                (success-> {}
                           colorizer
                           weaponizer

--- a/test/serum/t_core.clj
+++ b/test/serum/t_core.clj
@@ -148,21 +148,24 @@
   (fail-let [encumbered {:success false}]
             "I got a rock") => "I got a rock")
 
-(let [colorizer (fn [m]
-                  (-> m
-                      (assoc :color "blue")
-                      (assoc :success true)))
-      weaponizer (fn [m]
-                   (-> m
-                       (assoc :weapon "doughnut")
-                       (assoc :success true)))
-      hipifier (fn [m]
-                 (-> m
-                     (assoc :outfit "beanie")
-                     (assoc :success true)))
-      love-infuser (fn [m]
-                     (-> m
-                         (assoc :success false)))]
+(letfn [(colorizer [m]
+          (assoc m
+                 :color "blue"
+                 :success true))
+        (weaponizer [m]
+          (assoc m
+                 :weapon "doughnut"
+                 :success true))
+        (hipifier [m]
+          (assoc m
+                 :outfit "beanie"
+                 :success true))
+        (love-infuser [m]
+          (assoc m :success false))
+        (humidifier [m & args]
+          (assoc m
+                 :somesum (reduce + args)
+                 :success true))]
 
   (fact "success-> all succeeding list-free"
                (success-> {}
@@ -189,6 +192,16 @@
                                           :color "blue"
                                           :weapon "doughnut"
                                           :outfit "beanie"})
+
+  (fact "success-> success with multiple arguments"
+               (success-> (colorizer {})
+                          (weaponizer)
+                          (hipifier)
+                          (humidifier 123 74 82)) => {:success true
+                                                      :color "blue"
+                                                      :weapon "doughnut"
+                                                      :outfit "beanie"
+                                                      :somesum 279})
 
   (fact "success-> first failure list-free"
                (success-> {}

--- a/test/serum/t_core.clj
+++ b/test/serum/t_core.clj
@@ -262,3 +262,9 @@
   (attempt (/ 1 0) (fn [e] (.getMessage e))) => "Divide by zero"
   (attempt (/ 1 0) (fn [e] nil)) => nil
   (attempt (/ 1 2) (fn [e] e)) => 1/2)
+
+(fact "divert"
+  (divert
+   (do
+     (print "escape-pod")
+     7)) => [7 "escape-pod"])


### PR DESCRIPTION
Added `success->` and `divert` macros to serum.core
Added serum.async namespace with `fire!`, `chan->seq`, `map-async`