### PR TITLE
0.9.2 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject waffletower/serum "0.9.1"
+(defproject waffletower/serum "0.9.2"
   :description "Clojure library of utility functions and macros"
   :url "https://github.com/waffletower/serum"
   :license {:name "Eclipse Public License"

--- a/src/serum/async.clj
+++ b/src/serum/async.clj
@@ -71,17 +71,16 @@
    (let [input-channel (a/chan n)
          output-channel (a/chan n)]
      (a/onto-chan input-channel coll)
-     (a/pipeline-async
+     (a/pipeline-blocking
        n
        output-channel
-       (fn [x c]
-         (let [fx (try
-                    (f x)
-                    (catch Throwable e
-                      (do
-                        (a/close! input-channel)
-                        e)))]
-           (a/>!! c fx))
-         (a/close! c))
+       (map
+         (fn [x]
+           (try
+             (f x)
+             (catch Throwable e
+               (do
+                 (a/close! input-channel)
+                 e)))))
        input-channel)
      (chan->seq output-channel))))


### PR DESCRIPTION
use core.async/pipeline-blocking rather than pipeline-async for 'map-async' implementation.
rewrote execution wrapper function as a 'map' transducer/xform. no longer requires additional channel argument.